### PR TITLE
refactor(notes): improve mobile UI with bottom sheet and drag-to-close

### DIFF
--- a/components/dashboard/NotesTab.tsx
+++ b/components/dashboard/NotesTab.tsx
@@ -1,13 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { supabase } from '../../lib/supabase'
-import { renderProfileAvatar, ProfileData } from '../../lib/avatar-utils'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Textarea } from '../ui/textarea'
-import { Card, CardHeader, CardContent } from '../ui/card'
-import { Badge } from '../ui/badge'
-import { Avatar } from '../ui/avatar'
+import { Card } from '../ui/card'
 import { AppHeader } from '../ui/AppHeader'
 import {
   Dialog,
@@ -16,17 +13,21 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '../ui/sheet'
 import { AppConfig } from '../../lib/app-types'
 import { 
-  Plus, 
-  FileText, 
   Star, 
   Trash2, 
   Edit3,
-  Calendar,
-  User
+  Eye,
+  Calendar
 } from 'lucide-react'
-import MDEditor from '@uiw/react-md-editor'
 
 interface Note {
   id: string
@@ -63,34 +64,27 @@ export const NotesTab: React.FC<NotesTabProps> = ({
   isGroupOwner,
   appConfig
 }) => {
+  // Create note modal states
   const [showCreateModal, setShowCreateModal] = useState(false)
-  const [showViewModal, setShowViewModal] = useState(false)
-  const [showEditModal, setShowEditModal] = useState(false)
-  const [selectedNote, setSelectedNote] = useState<Note | null>(null)
-  const [editingNote, setEditingNote] = useState<Note | null>(null)
-  const [showConfirmImportant, setShowConfirmImportant] = useState(false)
-  const [noteToToggle, setNoteToToggle] = useState<Note | null>(null)
-  
-  // Form states
   const [newNoteTitle, setNewNoteTitle] = useState('')
   const [newNoteContent, setNewNoteContent] = useState('')
-  const [editNoteTitle, setEditNoteTitle] = useState('')
-  const [editNoteContent, setEditNoteContent] = useState('')
   
+  // Sheet states (unified view/edit)
+  const [isSheetOpen, setIsSheetOpen] = useState(false)
+  const [activeNote, setActiveNote] = useState<Note | null>(null)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editTitle, setEditTitle] = useState('')
+  const [editContent, setEditContent] = useState('')
+  
+  // Other states
+  const [showConfirmImportant, setShowConfirmImportant] = useState(false)
+  const [noteToToggle, setNoteToToggle] = useState<Note | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
-
-  // Check if mobile on mount and window resize
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768)
-    }
-    
-    checkMobile()
-    window.addEventListener('resize', checkMobile)
-    
-    return () => window.removeEventListener('resize', checkMobile)
-  }, [])
+  
+  // Drag handle ref for drag-to-close
+  const dragHandleRef = useRef<HTMLDivElement>(null)
+  const dragStartY = useRef<number>(0)
+  const isDragging = useRef<boolean>(false)
 
   // Listen for custom events from BottomActions
   useEffect(() => {
@@ -111,11 +105,130 @@ export const NotesTab: React.FC<NotesTabProps> = ({
     setNewNoteContent('')
   }
 
-  const resetEditForm = () => {
-    setEditNoteTitle('')
-    setEditNoteContent('')
-    setEditingNote(null)
+  const closeSheet = () => {
+    setIsSheetOpen(false)
+    setIsEditing(false)
+    setActiveNote(null)
+    setEditTitle('')
+    setEditContent('')
   }
+
+  // Drag-to-close handlers
+  useEffect(() => {
+    if (!isSheetOpen) return
+    
+    let cleanup: (() => void) | null = null
+    
+    // Small delay to ensure DOM is ready
+    const timeoutId = setTimeout(() => {
+      const handle = dragHandleRef.current
+      if (!handle) return
+
+      const getSheetContent = (): HTMLElement | null => {
+        // Try multiple selectors to find the sheet content
+        let element = handle.closest('[data-radix-dialog-content]') as HTMLElement
+        if (element) return element
+        
+        element = handle.closest('[role="dialog"]') as HTMLElement
+        if (element) return element
+        
+        // Fallback: find by querying the document
+        element = document.querySelector('[data-radix-dialog-content][data-state="open"]') as HTMLElement
+        if (element) return element
+        
+        // Last resort: traverse up the DOM tree
+        let parent = handle.parentElement
+        while (parent) {
+          if (parent.hasAttribute('data-radix-dialog-content') || parent.getAttribute('role') === 'dialog') {
+            return parent
+          }
+          parent = parent.parentElement
+        }
+        
+        return null
+      }
+
+      const handleTouchStart = (e: TouchEvent) => {
+        e.stopPropagation()
+        dragStartY.current = e.touches[0].clientY
+        isDragging.current = true
+      }
+
+      const handleTouchMove = (e: TouchEvent) => {
+        if (!isDragging.current) return
+        e.preventDefault()
+        e.stopPropagation()
+        
+        const currentY = e.touches[0].clientY
+        const deltaY = currentY - dragStartY.current
+        
+        // Only allow dragging down
+        if (deltaY > 0) {
+          const sheetContent = getSheetContent()
+          if (sheetContent) {
+            const translateY = Math.min(deltaY, 200)
+            sheetContent.style.transform = `translateY(${translateY}px)`
+            sheetContent.style.transition = 'none'
+          }
+        }
+      }
+
+      const handleTouchEnd = (e: TouchEvent) => {
+        if (!isDragging.current) return
+        isDragging.current = false
+        
+        const currentY = e.changedTouches[0].clientY
+        const deltaY = currentY - dragStartY.current
+        
+        const sheetContent = getSheetContent()
+        if (sheetContent) {
+          sheetContent.style.transition = 'transform 0.2s ease-out'
+          
+          // If dragged down more than 80px, close the sheet
+          if (deltaY > 80) {
+            setIsSheetOpen(false)
+            setIsEditing(false)
+            setActiveNote(null)
+            setEditTitle('')
+            setEditContent('')
+          } else {
+            // Snap back
+            sheetContent.style.transform = ''
+          }
+        }
+      }
+
+      // Make the drag handle and header area draggable
+      const headerArea = handle.nextElementSibling as HTMLElement
+      
+      handle.addEventListener('touchstart', handleTouchStart, { passive: false })
+      handle.addEventListener('touchmove', handleTouchMove, { passive: false })
+      handle.addEventListener('touchend', handleTouchEnd, { passive: false })
+      
+      if (headerArea) {
+        headerArea.addEventListener('touchstart', handleTouchStart, { passive: false })
+        headerArea.addEventListener('touchmove', handleTouchMove, { passive: false })
+        headerArea.addEventListener('touchend', handleTouchEnd, { passive: false })
+      }
+
+      cleanup = () => {
+        handle.removeEventListener('touchstart', handleTouchStart)
+        handle.removeEventListener('touchmove', handleTouchMove)
+        handle.removeEventListener('touchend', handleTouchEnd)
+        
+        if (headerArea) {
+          headerArea.removeEventListener('touchstart', handleTouchStart)
+          headerArea.removeEventListener('touchmove', handleTouchMove)
+          headerArea.removeEventListener('touchend', handleTouchEnd)
+        }
+      }
+    }, 100)
+
+    return () => {
+      clearTimeout(timeoutId)
+      if (cleanup) cleanup()
+    }
+  }, [isSheetOpen])
 
   const createNote = async () => {
     if (!newNoteTitle.trim() || !newNoteContent.trim() || !isOnline) return
@@ -145,22 +258,21 @@ export const NotesTab: React.FC<NotesTabProps> = ({
   }
 
   const updateNote = async () => {
-    if (!editingNote || !editNoteTitle.trim() || !editNoteContent.trim() || !isOnline) return
+    if (!activeNote || !editTitle.trim() || !editContent.trim() || !isOnline) return
 
     setIsLoading(true)
     try {
       const { error } = await supabase
         .from('notes')
         .update({
-          title: editNoteTitle.trim(),
-          content: editNoteContent.trim()
+          title: editTitle.trim(),
+          content: editContent.trim()
         })
-        .eq('id', editingNote.id)
+        .eq('id', activeNote.id)
 
       if (error) throw error
       
-      setShowEditModal(false)
-      resetEditForm()
+      closeSheet()
       onUpdate()
     } catch (error) {
       console.error('Error updating note:', error)
@@ -179,25 +291,35 @@ export const NotesTab: React.FC<NotesTabProps> = ({
         .eq('id', noteId)
 
       if (error) throw error
+      closeSheet()
       onUpdate()
     } catch (error) {
       console.error('Error deleting note:', error)
     }
   }
 
-  const handleViewNote = (note: Note) => {
-    setSelectedNote(note)
-    setShowViewModal(true)
+  const handleNoteClick = (note: Note) => {
+    setActiveNote(note)
+    setEditTitle(note.title)
+    setEditContent(note.content)
+    setIsEditing(false)
+    setIsSheetOpen(true)
   }
 
-  const handleEditNote = (note: Note) => {
-    setEditingNote(note)
-    setEditNoteTitle(note.title)
-    setEditNoteContent(note.content)
-    setShowEditModal(true)
+  const handleToggleEditMode = () => {
+    setIsEditing(!isEditing)
   }
 
-  const handleToggleImportant = (note: Note) => {
+  const handleCancelEdit = () => {
+    if (activeNote) {
+      setEditTitle(activeNote.title)
+      setEditContent(activeNote.content)
+      setIsEditing(false)
+    }
+  }
+
+  const handleToggleImportant = (note: Note, e?: React.MouseEvent) => {
+    if (e) e.stopPropagation()
     if (!isGroupOwner || !isOnline) return
     
     setNoteToToggle(note)
@@ -243,15 +365,9 @@ export const NotesTab: React.FC<NotesTabProps> = ({
     })
   }
 
-  const getPreviewText = (content: string, maxLength: number = 100) => {
-    // Remove markdown formatting and get plain text
+  const getPreviewText = (content: string, maxLength: number = 80) => {
     const plainText = content
-      .replace(/#+\s+/g, '') // Remove headers
-      .replace(/\*\*(.*?)\*\*/g, '$1') // Remove bold
-      .replace(/\*(.*?)\*/g, '$1') // Remove italic
-      .replace(/`(.*?)`/g, '$1') // Remove inline code
-      .replace(/\[(.*?)\]\(.*?\)/g, '$1') // Remove links
-      .replace(/\n+/g, ' ') // Replace newlines with spaces
+      .replace(/\n+/g, ' ')
       .trim()
 
     return plainText.length > maxLength ? `${plainText.slice(0, maxLength)}...` : plainText
@@ -279,19 +395,9 @@ export const NotesTab: React.FC<NotesTabProps> = ({
       )}
       
       {/* Header */}
-      <div className="flex justify-between items-center">
-        {!appConfig && (
-          <h2 className="text-xl sm:text-2xl font-bold">Notes</h2>
-        )}
-        <div className="flex items-center gap-2">
-          {notes.filter(note => note.is_important).length > 0 && (
-            <Badge variant="secondary" className="hidden sm:flex">
-              <Star className="h-3 w-3 mr-1 fill-current" />
-              Important
-            </Badge>
-          )}
-        </div>
-      </div>
+      {!appConfig && (
+        <h2 className="text-xl sm:text-2xl font-bold">Notes</h2>
+      )}
 
       {/* Notes Grid */}
       {sortedNotes.length === 0 ? (
@@ -305,102 +411,28 @@ export const NotesTab: React.FC<NotesTabProps> = ({
           </p>
         </div>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
           {sortedNotes.map((note) => (
             <Card 
               key={note.id} 
-              className={`cursor-pointer hover:shadow-lg transition-shadow duration-200 ${
-                note.is_important ? 'ring-2 ring-amber-200 bg-amber-50/50 dark:bg-amber-950/10 dark:ring-amber-800' : ''
+              className={`p-3 cursor-pointer hover:shadow-md transition-shadow duration-200 ${
+                note.is_important ? 'ring-2 ring-amber-400/50 bg-amber-50/50 dark:bg-amber-950/20' : ''
               }`}
-              onClick={() => handleViewNote(note)}
+              onClick={() => handleNoteClick(note)}
             >
-              <CardHeader className="pb-3">
-                <div className="flex items-start justify-between gap-2">
-                  <h3 className="text-lg font-semibold truncate">{note.title}</h3>
-                  <div className="flex items-center gap-1 flex-shrink-0">
-                    {isGroupOwner ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleToggleImportant(note)
-                        }}
-                        disabled={!isOnline}
-                        className={`h-8 w-8 p-0 ${
-                          note.is_important ? 'text-amber-500' : 'text-muted-foreground hover:text-amber-500'
-                        }`}
-                        title={note.is_important ? 'Remove from important' : 'Mark as important'}
-                      >
-                        <Star className={`h-5 w-5 ${note.is_important ? 'fill-current' : ''}`} />
-                      </Button>
-                    ) : (
-                      note.is_important && (
-                        <Star className="h-5 w-5 text-amber-500 fill-current" />
-                      )
-                    )}
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="pt-0">
-                <p className="text-sm text-muted-foreground mb-4 line-clamp-3">
-                  {getPreviewText(note.content)}
-                </p>
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                  <div className="flex items-center gap-2">
-                    <div className="flex items-center gap-1">
-                      <Calendar className="h-3 w-3" />
-                      <span>{formatDate(note.created_at)}</span>
-                    </div>
-                    {note.creator_profile && (
-                      <div className="flex items-center gap-1">
-                        <Avatar className="h-4 w-4">
-                          {renderProfileAvatar({
-                            id: note.created_by,
-                            email: note.creator_profile.email,
-                            display_name: note.creator_profile.display_name,
-                            profile_image: note.creator_profile.profile_image,
-                            updated_at: note.created_at
-                          }, { size: 'sm', fallbackTextSize: 'xs' })}
-                        </Avatar>
-                        <span>
-                          {note.created_by === currentUserId 
-                            ? 'You' 
-                            : note.creator_profile.display_name || note.creator_profile.email || 'Member'}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                  {note.created_by === currentUserId && (
-                    <div className="flex items-center gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleEditNote(note)
-                        }}
-                        disabled={!isOnline}
-                        className="h-8 w-8 p-0"
-                      >
-                        <Edit3 className="h-3 w-3" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          deleteNote(note.id)
-                        }}
-                        disabled={!isOnline}
-                        className="h-8 w-8 p-0 text-destructive hover:text-destructive/90"
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              </CardContent>
+              <div className="flex items-start justify-between gap-2 mb-1">
+                <h3 className="text-sm font-medium truncate flex-1">{note.title}</h3>
+                {note.is_important && (
+                  <Star className="h-3 w-3 text-amber-500 fill-current flex-shrink-0" />
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+                {getPreviewText(note.content)}
+              </p>
+              <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                <Calendar className="h-2.5 w-2.5" />
+                <span>{formatDate(note.created_at)}</span>
+              </div>
             </Card>
           ))}
         </div>
@@ -408,11 +440,11 @@ export const NotesTab: React.FC<NotesTabProps> = ({
 
       {/* Create Note Modal */}
       <Dialog open={showCreateModal} onOpenChange={setShowCreateModal}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Create New Note</DialogTitle>
             <DialogDescription>
-              Write a new note for your family. You can use markdown formatting.
+              Write a new note for your family.
             </DialogDescription>
           </DialogHeader>
           
@@ -428,30 +460,15 @@ export const NotesTab: React.FC<NotesTabProps> = ({
               />
             </div>
 
-
-
             <div>
               <Label>Content</Label>
-              {isMobile ? (
-                <Textarea
-                  value={newNoteContent}
-                  onChange={(e) => setNewNoteContent(e.target.value)}
-                  placeholder="Write your note content..."
-                  className="mt-1 min-h-[200px] resize-none"
-                  rows={8}
-                />
-              ) : (
-                <div className="mt-1" data-color-mode="auto">
-                  <MDEditor
-                    value={newNoteContent}
-                    onChange={(val) => setNewNoteContent(val || '')}
-                    height={300}
-                    preview="edit"
-                    hideToolbar={false}
-                    visibleDragbar={false}
-                  />
-                </div>
-              )}
+              <Textarea
+                value={newNoteContent}
+                onChange={(e) => setNewNoteContent(e.target.value)}
+                placeholder="Write your note content..."
+                className="mt-1 min-h-[300px] text-sm resize-none"
+                rows={12}
+              />
             </div>
 
             <div className="flex justify-end space-x-2 pt-4">
@@ -475,145 +492,135 @@ export const NotesTab: React.FC<NotesTabProps> = ({
         </DialogContent>
       </Dialog>
 
-      {/* View Note Modal */}
-      <Dialog open={showViewModal} onOpenChange={setShowViewModal}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-          {selectedNote && (
+      {/* View/Edit Note Sheet */}
+      <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+        <SheetContent side="bottom" className="h-[85vh] flex flex-col p-0">
+          {activeNote && (
             <>
-              <DialogHeader>
-                <div className="flex items-center justify-between">
-                  <DialogTitle className="flex items-center gap-2">
-                    {selectedNote.title}
-                    {selectedNote.is_important && (
-                      <Star className="h-5 w-5 text-amber-500 fill-current" />
-                    )}
-                  </DialogTitle>
-                  {selectedNote.created_by === currentUserId && (
+              {/* Drag Handle */}
+              <div 
+                ref={dragHandleRef}
+                className="flex justify-center pt-3 pb-2 cursor-grab active:cursor-grabbing select-none"
+                style={{ touchAction: 'pan-y', WebkitUserSelect: 'none', userSelect: 'none' }}
+              >
+                <div className="w-12 h-1.5 bg-muted-foreground/30 rounded-full" />
+              </div>
+              
+              <SheetHeader className="px-4 sm:px-6 pt-2 sm:pt-4 pb-3 sm:pb-4 border-b select-none" style={{ touchAction: 'pan-y' }}>
+                {/* Icons row on top */}
+                <div className="flex items-center gap-1.5 sm:gap-2 mb-2 sm:mb-3">
+                  {/* View/Edit toggle */}
+                  {activeNote.created_by === currentUserId && (
                     <Button
-                      variant="outline"
+                      variant="ghost"
                       size="sm"
-                      onClick={() => {
-                        setShowViewModal(false)
-                        handleEditNote(selectedNote)
-                      }}
+                      onClick={handleToggleEditMode}
                       disabled={!isOnline}
+                      className="h-8 sm:h-9 px-2 sm:px-3 text-xs sm:text-sm"
                     >
-                      <Edit3 className="h-4 w-4 mr-1" />
-                      Edit
+                      {isEditing ? (
+                        <>
+                          <Eye className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-1.5" />
+                          <span className="hidden sm:inline">View</span>
+                        </>
+                      ) : (
+                        <>
+                          <Edit3 className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-1.5" />
+                          <span className="hidden sm:inline">Edit</span>
+                        </>
+                      )}
                     </Button>
                   )}
-                </div>
-                <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
-                  <div className="flex items-center gap-1">
-                    <Calendar className="h-3 w-3" />
-                    <span>Created {formatDate(selectedNote.created_at)}</span>
+                  
+                  {/* Star toggle (owner only) */}
+                  {isGroupOwner && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={(e) => handleToggleImportant(activeNote, e)}
+                      disabled={!isOnline}
+                      className={`h-8 w-8 sm:h-9 sm:w-9 p-0 ${
+                        activeNote.is_important ? 'text-amber-500' : ''
+                      }`}
+                      title={activeNote.is_important ? 'Remove from important' : 'Mark as important'}
+                    >
+                      <Star className={`h-3.5 w-3.5 sm:h-4 sm:w-4 ${activeNote.is_important ? 'fill-current' : ''}`} />
+                    </Button>
+                  )}
+                  
+                  {/* Delete button (owner only) */}
+                  {activeNote.created_by === currentUserId && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => deleteNote(activeNote.id)}
+                      disabled={!isOnline}
+                      className="h-8 w-8 sm:h-9 sm:w-9 p-0 text-destructive hover:text-destructive/90"
+                      title="Delete note"
+                    >
+                      <Trash2 className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+                    </Button>
+                  )}
+                  
+                  {/* Date info */}
+                  <div className="flex items-center gap-1 text-[10px] text-muted-foreground ml-auto">
+                    <Calendar className="h-2.5 w-2.5" />
+                    <span>{formatDate(activeNote.created_at)}</span>
                   </div>
-                  {selectedNote.creator_profile && (
-                    <div className="flex items-center gap-1.5">
-                      <User className="h-3 w-3" />
-                      <Avatar className="h-5 w-5">
-                        {renderProfileAvatar({
-                          id: selectedNote.created_by,
-                          email: selectedNote.creator_profile.email,
-                          display_name: selectedNote.creator_profile.display_name,
-                          profile_image: selectedNote.creator_profile.profile_image,
-                          updated_at: selectedNote.created_at
-                        }, { size: 'sm', fallbackTextSize: 'xs' })}
-                      </Avatar>
-                      <span>
-                        {selectedNote.created_by === currentUserId 
-                          ? 'You' 
-                          : selectedNote.creator_profile.display_name || selectedNote.creator_profile.email || 'Member'}
-                      </span>
-                    </div>
-                  )}
-                  {selectedNote.updated_at !== selectedNote.created_at && (
-                    <div className="flex items-center gap-1">
-                      <Edit3 className="h-3 w-3" />
-                      <span>Updated {formatDate(selectedNote.updated_at)}</span>
-                    </div>
-                  )}
                 </div>
-              </DialogHeader>
+                
+                {/* Title row below icons */}
+                {isEditing ? (
+                  <Input
+                    value={editTitle}
+                    onChange={(e) => setEditTitle(e.target.value)}
+                    className="text-base font-semibold"
+                    placeholder="Note title..."
+                  />
+                ) : (
+                  <SheetTitle className="text-base font-semibold">
+                    {activeNote.title}
+                  </SheetTitle>
+                )}
+              </SheetHeader>
               
-              <div className="bg-muted/30 rounded-lg p-4 border overflow-hidden">
-                <div className="prose prose-sm max-w-none dark:prose-invert bg-background rounded-md p-4 shadow-sm text-sm" data-color-mode="auto">
-                  <MDEditor.Markdown source={selectedNote.content} />
-                </div>
+              <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-3 sm:py-4">
+                {isEditing ? (
+                  <Textarea
+                    value={editContent}
+                    onChange={(e) => setEditContent(e.target.value)}
+                    className="min-h-full text-sm resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 p-0"
+                    placeholder="Write your note content..."
+                  />
+                ) : (
+                  <div className="whitespace-pre-wrap text-sm leading-relaxed">
+                    {activeNote.content}
+                  </div>
+                )}
               </div>
+              
+              {isEditing && (
+                <SheetFooter className="px-4 sm:px-6 py-3 sm:py-4 border-t">
+                  <Button 
+                    variant="outline" 
+                    onClick={handleCancelEdit}
+                    className="flex-1 sm:flex-none"
+                  >
+                    Cancel
+                  </Button>
+                  <Button 
+                    onClick={updateNote}
+                    disabled={!editTitle.trim() || !editContent.trim() || isLoading || !isOnline}
+                    className="flex-1 sm:flex-none"
+                  >
+                    {isLoading ? 'Saving...' : 'Save Changes'}
+                  </Button>
+                </SheetFooter>
+              )}
             </>
           )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Edit Note Modal */}
-      <Dialog open={showEditModal} onOpenChange={setShowEditModal}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Edit Note</DialogTitle>
-            <DialogDescription>
-              Make changes to your note. You can use markdown formatting.
-            </DialogDescription>
-          </DialogHeader>
-          
-          <div className="space-y-4">
-            <div>
-              <Label htmlFor="edit-title">Title</Label>
-              <Input
-                id="edit-title"
-                value={editNoteTitle}
-                onChange={(e) => setEditNoteTitle(e.target.value)}
-                placeholder="Enter note title..."
-                className="mt-1"
-              />
-            </div>
-
-
-
-            <div>
-              <Label>Content</Label>
-              {isMobile ? (
-                <Textarea
-                  value={editNoteContent}
-                  onChange={(e) => setEditNoteContent(e.target.value)}
-                  placeholder="Write your note content..."
-                  className="mt-1 min-h-[200px] resize-none"
-                  rows={8}
-                />
-              ) : (
-                <div className="mt-1" data-color-mode="auto">
-                  <MDEditor
-                    value={editNoteContent}
-                    onChange={(val) => setEditNoteContent(val || '')}
-                    height={300}
-                    preview="edit"
-                    hideToolbar={false}
-                    visibleDragbar={false}
-                  />
-                </div>
-              )}
-            </div>
-
-            <div className="flex justify-end space-x-2 pt-4">
-              <Button 
-                variant="outline" 
-                onClick={() => {
-                  setShowEditModal(false)
-                  resetEditForm()
-                }}
-              >
-                Cancel
-              </Button>
-              <Button 
-                onClick={updateNote}
-                disabled={!editNoteTitle.trim() || !editNoteContent.trim() || isLoading || !isOnline}
-              >
-                {isLoading ? 'Saving...' : 'Save Changes'}
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+        </SheetContent>
+      </Sheet>
 
       {/* Confirmation Modal for Important Toggle */}
       <Dialog open={showConfirmImportant} onOpenChange={setShowConfirmImportant}>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -35,7 +35,7 @@ const sheetVariants = cva(
       side: {
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          "inset-x-0 bottom-0 border-t rounded-t-[2rem] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
           "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",

--- a/next.config.js
+++ b/next.config.js
@@ -16,8 +16,6 @@ const nextConfig = {
   experimental: {
     // appDir is no longer needed in Next.js 14
   },
-  // Allow CSS imports from specific node_modules packages
-  transpilePackages: ["@uiw/react-md-editor", "@uiw/react-markdown-preview"],
 };
 
 module.exports = withPWA(nextConfig);


### PR DESCRIPTION
- Replace MDEditor with plain Textarea for simpler, faster editing
- Implement bottom sheet (side=bottom) for mobile-native experience
- Add drag-to-close functionality with visual feedback
- Redesign note cards with minimal layout (smaller fonts, no avatars)
- Add rounded top corners to sheet component
- Reorder header: icons on top, title below for better UX
- Optimize mobile spacing and typography throughout
- Remove MDEditor dependency and transpile config from next.config.js